### PR TITLE
Set selection to use Matlab characteristics, add simple guide star selection, use guide star SNR in output

### DIFF
--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -207,7 +207,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
         acq_stars = select_ri_stars(ra_pnt, dec_pnt, cone_stars)
         acq_tccd, nacq = max_temp(time=time, stars=acq_stars)
         guide_stars.sort('MAG_ACA')
-        guide_tccd = t_lose_star(guide_stars[-1]['MAG_ACA']) if len(guide_stars) == 5 else -21
+        guide_tccd = t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21
         t_ccd = np.min([acq_tccd, guide_tccd])
         if t_ccd >= WARM_T_CCD:
             nom = {'roll': nom_roll,
@@ -227,7 +227,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     guide_stars = select_guide_stars(ra_pnt, dec_pnt, nom_roll, cone_stars)
     guide_stars.sort('MAG_ACA')
     acq_tccd, nacq = max_temp(time=time, stars=acq_stars)
-    guide_tccd = t_lose_star(guide_stars[-1]['MAG_ACA']) if len(guide_stars) == 5 else -21
+    guide_tccd = t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21
     t_ccd = np.min([acq_tccd, guide_tccd])
     nom = {'roll': nom_roll,
            'acq_tccd': acq_tccd,
@@ -267,7 +267,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
         guide_stars = select_guide_stars(ra_pnt, dec_pnt, roll, cone_stars)
         guide_stars.sort('MAG_ACA')
         acq_tccd, nacq = max_temp(time=time, stars=acq_stars)
-        guide_tccd = t_lose_star(guide_stars[-1]['MAG_ACA']) if len(guide_stars) == 5 else -21
+        guide_tccd = t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21
         t_ccd = np.min([acq_tccd, guide_tccd])
         all_rolls[roll] = t_ccd
         if t_ccd is not None:

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -40,6 +40,10 @@ import astropy.units as u
 import acq_char
 import mini_sausage
 
+# Expand the last stage of guide selection in SAUSAGE to get some fainter stars to use them
+# to set a temperature
+mini_sausage.STAR_CHAR['Guide'][-1]['Inertial']['MagLimit'][1] = 11.0
+
 
 PLANNING_LIMIT = -11.5
 EDGE_DIST = 30

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -601,12 +601,12 @@ def plot_hist_table(t_ccd_table):
 
 def check_update_needed(target, obsdir):
     json_parfile = os.path.join(obsdir, 'obsinfo.json')
-    parlist = ['ra', 'dec', 'y_offset', 'z_offset', 'report_start', 'report_stop', 'daystep',
-               'chandra_aca']
+    parlist = ['ra', 'dec', 'y_offset', 'z_offset', 'report_start', 'report_stop', 'daystep']
     try:
         pars = json.load(open(json_parfile))
         for par in parlist:
             assert np.allclose(pars[par], target[par], atol=1e-10)
+        assert pars['chandra_aca'] == target['chandra_aca']
     except:
         return True
     return False
@@ -622,6 +622,8 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
     if not redo and os.path.exists(table_file) and os.path.exists(just_roll_file):
         t_ccd_table = Table.read(table_file, format='ascii.fixed_width_two_line')
         t_ccd_roll = Table.read(just_roll_file, format='ascii.fixed_width_two_line')
+    elif not redo:
+        return None
     else:
         t_ccd_table, t_ccd_roll = t_ccd_for_attitude(
             ra, dec,

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -58,7 +58,6 @@ ROLL_TABLE = Table.read(os.path.join(TASK_DATA, 'roll_limits.dat'), format='asci
 # Save temperature calc a combination of stars
 # indexed by hash of agasc ids
 T_CCD_CACHE = {}
-G_T_CCD_CACHE = {}
 
 # Star catalog for an attitude (ignores proper motion)
 CAT_CACHE = {}

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -456,6 +456,7 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
                 'best_gui_hash': hashlib.md5(np.sort(best['guide_stars']['AGASC_ID'])).hexdigest(),
                 'comment': r_data_check['comment'],
                 })
+            all_rolls[nom_roll] = np.min([nom['guide_tccd2'], nom['acq_tccd']])
             continue
         t_ccd_roll_data = get_t_ccd_roll(
             ra, dec, cycle, detector, too, y_offset, z_offset,

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -393,6 +393,7 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
                 'day': day[0:8],
                 'caldate': DateTime(day).caldate[4:9],
                 'pitch': day_pitch,
+                'roll_range': np.nan,
                 'nom_roll': np.nan,
                 'nom_t_ccd': np.nan,
                 'nom_acq_tccd': np.nan,
@@ -414,7 +415,8 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
             temps["{}".format(day[0:8])] = {
                 'day': day[0:8],
                 'caldate': DateTime(day).caldate[4:9],
-                'pitch': day_pitch}
+                'pitch': day_pitch,
+                'roll_range': get_rolldev(day_pitch)}
             last_good_day = day
             last_good_pitch = day_pitch
 
@@ -485,7 +487,7 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
                 'best_gui_hash': hashlib.md5(np.sort(best['guide_stars']['AGASC_ID'])).hexdigest(),
                 'comment': r_data_check['comment'],
                 })
-    t_ccd_table = Table(temps.values())['day', 'caldate', 'pitch',
+    t_ccd_table = Table(temps.values())['day', 'caldate', 'pitch', 'roll_range',
                                         'nom_roll', 'nom_t_ccd', 'nom_acq_tccd', 'nom_gui_5star', 'nom_gui_4star','nom_gui_3star',
                                         'best_roll', 'best_t_ccd', 'best_acq_tccd', 'best_gui_5star','best_gui_4star', 'best_gui_3star',
                                         'nom_acq_hash', 'best_acq_hash',
@@ -675,6 +677,7 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
     jinja_env.line_statement_prefix = '#'
     template = jinja_env.get_template('target.html')
     t_ccd_table['pitch'].format = '.2f'
+    t_ccd_table['roll_range'].format = '.1f'
     t_ccd_table['nom_roll'].format = '.2f'
     t_ccd_table['nom_t_ccd'].format = '.2f'
     t_ccd_table['nom_acq_tccd'].format = '.2f'
@@ -690,6 +693,7 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
     formats = {'day': '%s',
                'caldate': '%s',
                'pitch': '%5.2f',
+               'roll_range': '%3.1f',
                'nom_roll': '%5.2f',
                'nom_t_ccd': '%5.2f',
                'nom_acq_tccd': '%5.2f',
@@ -710,7 +714,7 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
     masked_table = t_ccd_table[~np.isnan(t_ccd_table['nom_t_ccd'])]
     displaycols = masked_table.colnames
     if not debug:
-        displaycols = ['day', 'caldate', 'pitch',
+        displaycols = ['day', 'caldate', 'pitch', 'roll_range',
                        'nom_roll', 'nom_t_ccd', 'nom_acq_tccd', 'nom_gui_4star',
                        'best_roll', 'best_t_ccd', 'best_acq_tccd', 'best_gui_4star', 'comment']
     page = template.render(time_plot=tfig_html,

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -575,7 +575,7 @@ def plot_time_table(t_ccd_table):
                  'b.',
                  label='best roll t ccd')
     plt.grid()
-    plt.ylim(ymin=COLD_T_CCD, ymax=WARM_T_CCD + 3.0)
+    plt.ylim(ymin=COLD_T_CCD, ymax=WARM_T_CCD + 5.0)
     plt.xlim(xmin=cxctime2plotdate([day_secs[0]]),
              xmax=cxctime2plotdate([day_secs[-1]]))
     plt.legend(loc='upper left', title="", numpoints=1, handlelength=.5)

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -130,7 +130,7 @@ def select_stars(ra, dec, roll, cone_stars):
     id_key = (ra, dec, roll)
     updated_cone_stars = cone_stars
     if id_key not in CAT_CACHE:
-        CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_stars(
+        CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
             ra, dec, roll, cone_stars)
     return CAT_CACHE[id_key], updated_cone_stars
 
@@ -139,7 +139,7 @@ def select_ri_stars(ra, dec, cone_stars):
     id_key = (ra, dec)
     updated_cone_stars = cone_stars
     if id_key not in RI_CAT_CACHE:
-        RI_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_stars(
+        RI_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
             ra, dec, None, cone_stars, roll_indep=True)
     return RI_CAT_CACHE[id_key], updated_cone_stars
 
@@ -255,7 +255,7 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         raise ValueError("No stars found in 3 degree radius of {} {}".format(ra, dec))
 
     # get mag errs once for the field
-    cone_stars['mag_one_sig_err'], cone_stars['mag_one_sig_err2'] = mini_sausage.get_mag_errs(cone_stars)
+    #cone_stars['mag_one_sig_err'], cone_stars['mag_one_sig_err2'] = mini_sausage.get_mag_errs(cone_stars)
 
     # get a list of days
     days = start + np.arange(stop - start)

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -211,6 +211,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
         t_ccd = np.min([acq_tccd, guide_tccd])
         if t_ccd >= WARM_T_CCD:
             nom = {'roll': nom_roll,
+                   'q_pnt': q_pnt,
                    'acq_tccd': acq_tccd,
                    'guide_tccd1': t_lose_star(guide_stars[4]['MAG_ACA']) if len(guide_stars) == 5 else -21,
                    'guide_tccd2': t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21,
@@ -230,6 +231,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     guide_tccd = t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21
     t_ccd = np.min([acq_tccd, guide_tccd])
     nom = {'roll': nom_roll,
+           'q_pnt': q_pnt,
            'acq_tccd': acq_tccd,
            'guide_tccd1': t_lose_star(guide_stars[4]['MAG_ACA']) if len(guide_stars) == 5 else -21,
            'guide_tccd2': t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21,
@@ -274,6 +276,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
             if best_t_ccd is None or t_ccd > best_t_ccd:
                 best_t_ccd = t_ccd
                 best = {'roll': roll,
+                        'q_pnt': q_pnt,
                         'acq_tccd': acq_tccd,
                         'guide_tccd1': t_lose_star(guide_stars[4]['MAG_ACA']) if len(guide_stars) == 5 else -21,
                         'guide_tccd2': t_lose_star(guide_stars[3]['MAG_ACA']) if len(guide_stars) >= 4 else -21,
@@ -468,6 +471,20 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         cone_stars = t_ccd_roll_data['cone_stars']
         nom = t_ccd_roll_data['nomdata']
         best = t_ccd_roll_data['bestdata']
+
+        for roll, q in zip([nom['roll'], best['roll']], [nom['q_pnt'], best['q_pnt']]):
+            attfile = open(os.path.join(outdir, "roll_{:06.2f}.json".format(roll)), 'w')
+            attfile.write(json.dumps({'ra': q.ra,
+                                      'dec': q.dec,
+                                      'roll': q.roll,
+                                      'q1': q.q[0],
+                                      'q2': q.q[1],
+                                      'q3': q.q[2],
+                                      'q4': q.q[3]},
+                                     indent=4,
+                                     sort_keys=True))
+            attfile.close()
+
         temps[tday].update({
                 'nom_roll': nom['roll'],
                 'nom_t_ccd': np.min([nom['guide_tccd2'], nom['acq_tccd']]),

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python
-
 import os
 import warnings
-# Ignore known numexpr.necompiler and table.conditions warning
-warnings.filterwarnings(
-    'ignore',
-    message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
-    category=DeprecationWarning)
-
-
-from itertools import count
 import numpy as np
 import agasc
 import jinja2
-import re
 import shutil
 import hashlib
 import matplotlib
@@ -23,22 +13,25 @@ import matplotlib.pyplot as plt
 import json
 import mpld3
 
-from Ska.Matplotlib import plot_cxctime, cxctime2plotdate
+from astropy.table import Table
 
+from Ska.Matplotlib import plot_cxctime, cxctime2plotdate
 from Chandra.Time import DateTime
 import Ska.Sun
-from Ska.quatutil import radec2yagzag
-from Quaternion import Quat
 import chandra_aca
-from chandra_aca import calc_aca_from_targ
+from chandra_aca.transform import calc_aca_from_targ
 from chandra_aca.star_probs import t_ccd_warm_limit, set_acq_model_ms_filter
 from chandra_aca.drift import get_aca_offsets, get_target_aimpoint
 from chandra_aca import dark_model
-from astropy.table import Table
-from astropy.coordinates import SkyCoord, search_around_sky
-import astropy.units as u
-import acq_char
+
 import mini_sausage
+
+# Ignore known numexpr.necompiler and table.conditions warning
+warnings.filterwarnings(
+    'ignore',
+    message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
+    category=DeprecationWarning)
+
 
 # Expand the last stage of guide selection in SAUSAGE to get some fainter stars to use them
 # to set a temperature

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -129,47 +129,28 @@ def get_rolldev(pitch):
     return ROLL_TABLE['rolldev'][idx - 1]
 
 
-def select_stars(ra, dec, roll, cone_stars, outdir):
-    id_key = (ra, dec, roll)
+def select_stars(ra, dec, roll, cone_stars):
+    id_key = ("{:.5f}".format(ra),
+              "{:.5f}".format(dec),
+              "{:.5f}".format(roll))
     updated_cone_stars = cone_stars
-    id_hash = '{:.4f}_{:.4f}_{:.4f}'.format(ra, dec, roll)
     if id_key not in CAT_CACHE:
-        # First check if there's actually one on disk
-        if os.path.exists(os.path.join(outdir, "{}.dat".format(id_hash))):
-            CAT_CACHE[id_key] = Table.read(os.path.join(outdir, "{}.dat".format(id_hash)),
-                                      format="ascii")
-        else:
-            CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
-                ra, dec, roll, n=8, cone_stars=cone_stars)
-            CAT_CACHE[id_key].write(os.path.join(outdir, "{}.html".format(id_hash)),
-                                    format="jsviewer")
-            CAT_CACHE[id_key].write(os.path.join(outdir, "{}.dat".format(id_hash)),
-                                    format="ascii")
-
-    return CAT_CACHE[id_key], updated_cone_stars, id_hash
+        CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
+            ra, dec, roll, n=8, cone_stars=cone_stars)
+    return CAT_CACHE[id_key], updated_cone_stars
 
 
-def select_ri_stars(ra, dec, cone_stars, outdir):
-    id_key = (ra, dec)
+def select_ri_stars(ra, dec, cone_stars):
+    id_key = ("{:.5f}".format(ra),
+              "{:.5f}".format(dec))
     updated_cone_stars = cone_stars
-    id_hash = '{:.4f}_{:.4f}'.format(ra, dec)
     if id_key not in RI_CAT_CACHE:
-        # First check if there's actually one on disk
-        if os.path.exists(os.path.join(outdir, "{}.dat".format(id_hash))):
-            RI_CAT_CACHE[id_key]= Table.read(os.path.join(outdir, "{}.dat".format(id_hash)),
-                                      format="ascii")
-        else:
-            RI_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
-                ra, dec, None, n=8, cone_stars=cone_stars, roll_indep=True)
-            RI_CAT_CACHE[id_key].write(os.path.join(outdir, "{}.html".format(id_hash)),
-                            format="jsviewer")
-            RI_CAT_CACHE[id_key].write(os.path.join(outdir, "{}.dat".format(id_hash)),
-                            format="ascii")
-
-    return RI_CAT_CACHE[id_key], updated_cone_stars, id_hash
+        RI_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
+            ra, dec, None, n=8, cone_stars=cone_stars, roll_indep=True)
+    return RI_CAT_CACHE[id_key], updated_cone_stars
 
 
-def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, time, cone_stars, outdir):
+def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, time, cone_stars):
     """
     Loop over possible roll range for this pitch and return best
     and nominal temperature/roll combinations
@@ -192,19 +173,18 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     # if the offsets are both small, so the pointing attitude is relatively roll-independent
     # check the relatively roll independent circle
     if abs(y_offset) < .3 and abs(z_offset) < .3:
-        ri_data = select_ri_stars(ra_pnt, dec_pnt, cone_stars, outdir=outdir)
+        ri_data = select_ri_stars(ra_pnt, dec_pnt, cone_stars)
         roll_indep_stars = ri_data[0]
-        id_hash = ri_data[2]
         ri_t_ccd, ri_t_acq = max_temp(time=time, stars=roll_indep_stars)
         if (ri_t_ccd == WARM_T_CCD):
-            nom = (WARM_T_CCD, nom_roll, ri_t_acq, roll_indep_stars, id_hash)
+            nom = (WARM_T_CCD, nom_roll, ri_t_acq, roll_indep_stars)
             return {'nomdata': nom,
                     'bestdata': nom,
                     'rolls': {nom_roll: ri_t_ccd},
                     'cone_stars': cone_stars,
                     'roll_indep': True,
                     'comment': 'roll-independent'}
-    nom_stars, updated_cone_stars, nom_id_hash = select_stars(ra_pnt, dec_pnt, nom_roll, cone_stars, outdir=outdir)
+    nom_stars, updated_cone_stars = select_stars(ra_pnt, dec_pnt, nom_roll, cone_stars)
     cone_stars = updated_cone_stars
     nom_t_ccd, nom_n_acq = max_temp(time=time, stars=nom_stars)
     all_rolls = {nom_roll: nom_t_ccd}
@@ -234,7 +214,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
                                    (z_offset / 60.) + (aca_offset_z / 3600.))
         ra_pnt = q_pnt.ra
         dec_pnt = q_pnt.dec
-        roll_stars, updated_cone_stars, roll_id_hash = select_stars(ra_pnt, dec_pnt, roll, cone_stars, outdir=outdir)
+        roll_stars, updated_cone_stars = select_stars(ra_pnt, dec_pnt, roll, cone_stars)
         cone_stars = updated_cone_stars
         roll_t_ccd, roll_n_acq = max_temp(time=time, stars=roll_stars)
         all_rolls[roll] = roll_t_ccd
@@ -243,14 +223,13 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
                 best_t_ccd = roll_t_ccd
                 best_roll = roll
                 best_stars = roll_stars
-                best_id_hash = roll_id_hash
                 best_n_acq = roll_n_acq
                 if abs(roll - np.round(nom_roll)) > (roll_dev - d_roll):
                     best_is_max = True
             if (best_t_ccd == WARM_T_CCD):
                 break
-    nom =  (nom_t_ccd, nom_roll, nom_n_acq, nom_stars, nom_id_hash)
-    best = (best_t_ccd, best_roll, best_n_acq, best_stars, best_id_hash)
+    nom =  (nom_t_ccd, nom_roll, nom_n_acq, nom_stars)
+    best = (best_t_ccd, best_roll, best_n_acq, best_stars)
     comment = ''
     if best_is_max:
         comment = 'best roll at max offset'
@@ -271,6 +250,27 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
     CAT_CACHE.clear()
     global RI_CAT_CACHE
     RI_CAT_CACHE.clear()
+
+    # Load any previously obtained results into cache
+    t_ccd_file = os.path.join(outdir, "t_ccd_map.dat")
+    if os.path.exists(t_ccd_file):
+        t_ccd = Table.read(t_ccd_file, format='ascii')
+        for row in t_ccd:
+            T_CCD_CACHE[row['key']] = (row['t_ccd'], row['n_acqs'])
+    cat_file = os.path.join(outdir, "cat_map.dat")
+    if os.path.exists(cat_file):
+        cat = Table.read(cat_file, format="ascii")
+        for row in cat:
+            CAT_CACHE[(row['ra'], row['dec'], row['roll'])] = Table.read(
+                os.path.join(outdir, "{}_stars.dat".format(row['hash'])),
+                format='ascii')
+    ri_cat_file = os.path.join(outdir, "ri_cat_map.dat")
+    if os.path.exists(ri_cat_file):
+        cat = Table.read(ri_cat_file, format="ascii")
+        for row in cat:
+            RI_CAT_CACHE[(row['ra'], row['dec'])] = Table.read(
+                os.path.join(outdir, "{}_stars.dat".format(row['hash'])),
+                format='ascii')
 
     start = DateTime(start)
     stop = DateTime(stop)
@@ -324,12 +324,12 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         # Run the temperature thing once to see if this might be good for all rolls
         r_data_check = get_t_ccd_roll(
             ra, dec, cycle, detector, too, y_offset, z_offset,
-            last_good_pitch, time=last_good_day, cone_stars=cone_stars, outdir=outdir)
+            last_good_pitch, time=last_good_day, cone_stars=cone_stars)
 
         # If it is roll independent, write out the star hashes here
         if r_data_check['roll_indep']:
-            nom_t_ccd, nom_roll, nom_n_acq, nom_stars, nom_id_hash = r_data_check['nomdata']
-            best_t_ccd, best_roll, best_n_acq, best_stars, best_id_hash = r_data_check['bestdata']
+            nom_t_ccd, nom_roll, nom_n_acq, nom_stars = r_data_check['nomdata']
+            best_t_ccd, best_roll, best_n_acq, best_stars = r_data_check['bestdata']
 
     for tday in temps:
         # If this has already been defined/done for this day, continue
@@ -338,34 +338,34 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         # If roll independent copy in the value from that solution, but get nominal roll again
         # for this day
         if r_data_check['roll_indep']:
-            nom_t_ccd, nroll, nom_n_acq, nom_stars, nom_id_hash = r_data_check['nomdata']
-            best_t_ccd, broll, best_n_acq, best_stars, best_id_hash = r_data_check['bestdata']
+            nom_t_ccd, nroll, nom_n_acq, nom_stars = r_data_check['nomdata']
+            best_t_ccd, broll, best_n_acq, best_stars = r_data_check['bestdata']
             nom_roll = Ska.Sun.nominal_roll(ra, dec, tday)
             temps[tday].update({
                 'nom_roll': nom_roll,
                 'nom_t_ccd': nom_t_ccd,
                 'best_roll': nom_roll,
                 'best_t_ccd': best_t_ccd,
-                'nom_id_hash': nom_id_hash,
-                'best_id_hash': best_id_hash,
+                'nom_id_hash': hashlib.md5(np.sort(nom_stars['AGASC_ID'])).hexdigest(),
+                'best_id_hash': hashlib.md5(np.sort(best_stars['AGASC_ID'])).hexdigest(),
                 'comment': r_data_check['comment'],
                 })
             continue
         t_ccd_roll_data = get_t_ccd_roll(
             ra, dec, cycle, detector, too, y_offset, z_offset,
-            temps[tday]['pitch'], time=temps[tday]['day'], cone_stars=cone_stars, outdir=outdir)
+            temps[tday]['pitch'], time=temps[tday]['day'], cone_stars=cone_stars)
         all_day_rolls = t_ccd_roll_data['rolls']
         all_rolls.update(all_day_rolls)
         cone_stars = t_ccd_roll_data['cone_stars']
-        nom_t_ccd, nom_roll, nom_n_acq, nom_stars, nom_id_hash = t_ccd_roll_data['nomdata']
-        best_t_ccd, best_roll, best_n_acq, best_stars, best_id_hash = t_ccd_roll_data['bestdata']
+        nom_t_ccd, nom_roll, nom_n_acq, nom_stars = t_ccd_roll_data['nomdata']
+        best_t_ccd, best_roll, best_n_acq, best_stars = t_ccd_roll_data['bestdata']
         temps[tday].update({
                 'nom_roll': nom_roll,
                 'nom_t_ccd': nom_t_ccd,
                 'best_roll': best_roll,
                 'best_t_ccd': best_t_ccd,
-                'nom_id_hash': nom_id_hash,
-                'best_id_hash': best_id_hash,
+                'nom_id_hash': hashlib.md5(np.sort(nom_stars['AGASC_ID'])).hexdigest(),
+                'best_id_hash': hashlib.md5(np.sort(best_stars['AGASC_ID'])).hexdigest(),
                 'comment': t_ccd_roll_data['comment']
                 })
     t_ccd_table = Table(temps.values())['day', 'caldate', 'pitch',
@@ -378,6 +378,39 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
     if len(all_rolls) > 0:
         t_ccd_roll = Table(rows=all_rolls.items(), names=('roll', 't_ccd'))
         t_ccd_roll.sort('roll')
+
+    # Save anything useful and write out catalogs
+    t_ccds = [{'key': key, 't_ccd': T_CCD_CACHE[key][0], 'n_acqs': T_CCD_CACHE[key][1]}
+              for key in T_CCD_CACHE]
+    t_ccd_file = os.path.join(outdir, "t_ccd_map.dat")
+    Table(t_ccds).write(t_ccd_file, format='ascii')
+
+    cats = []
+    hashes = {}
+    for key in CAT_CACHE:
+        h = hashlib.md5(np.sort(CAT_CACHE[key]['AGASC_ID'])).hexdigest()
+        cats.append({'ra': key[0],
+                     'dec': key[1],
+                     'roll': key[2],
+                     'hash': h})
+        hashes[h] = CAT_CACHE[key]
+    if len(cats):
+        Table(cats)[['ra','dec','roll', 'hash']].write(cat_file, format='ascii')
+    ri_cats = []
+    for key in RI_CAT_CACHE:
+        h = hashlib.md5(np.sort(RI_CAT_CACHE[key]['AGASC_ID'])).hexdigest()
+        ri_cats.append({'ra': key[0],
+                        'dec': key[1],
+                        'hash': h})
+        hashes[h] = RI_CAT_CACHE[key]
+    if len(ri_cats):
+        Table(ri_cats)[['ra', 'dec', 'hash']].write(ri_cat_file, format='ascii')
+    for h in hashes:
+        starfile = os.path.join(outdir, "{}_stars.dat".format(h))
+        hashes[h].write(starfile, format='ascii')
+        hashes[h].write(os.path.join(outdir, "{}.html".format(h)),
+                        format='jsviewer')
+
     return t_ccd_table, t_ccd_roll
 
 
@@ -428,7 +461,8 @@ def plot_hist_table(t_ccd_table):
 
 def check_update_needed(target, obsdir):
     json_parfile = os.path.join(obsdir, 'obsinfo.json')
-    parlist = ['ra', 'dec', 'y_offset', 'z_offset', 'report_start', 'report_stop', 'daystep']
+    parlist = ['ra', 'dec', 'y_offset', 'z_offset', 'report_start', 'report_stop', 'daystep',
+               'chandra_aca']
     try:
         pars = json.load(open(json_parfile))
         for par in parlist:
@@ -466,7 +500,7 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
         parfile.write(json.dumps({'ra': ra, 'dec': dec, 'obsid': obsid,
                                   'y_offset': y_offset, 'z_offset': z_offset,
                                   'report_start': start.secs, 'report_stop': stop.secs,
-                                  'daystep': daystep},
+                                  'daystep': daystep, 'chandra_aca': chandra_aca.__version__},
                                  indent=4,
                                  sort_keys=True))
         parfile.close()

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -335,14 +335,16 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         # If this has already been defined/done for this day, continue
         if 'nom_roll' in temps[tday]:
             continue
-        # If roll independent copy in the value from that solution
+        # If roll independent copy in the value from that solution, but get nominal roll again
+        # for this day
         if r_data_check['roll_indep']:
-            nom_t_ccd, nom_roll, nom_n_acq, nom_stars = r_data_check['nomdata']
-            best_t_ccd, best_roll, best_n_acq, best_stars = r_data_check['bestdata']
+            nom_t_ccd, nroll, nom_n_acq, nom_stars, nom_id_hash = r_data_check['nomdata']
+            best_t_ccd, broll, best_n_acq, best_stars, best_id_hash = r_data_check['bestdata']
+            nom_roll = Ska.Sun.nominal_roll(ra, dec, tday)
             temps[tday].update({
                 'nom_roll': nom_roll,
                 'nom_t_ccd': nom_t_ccd,
-                'best_roll': best_roll,
+                'best_roll': nom_roll,
                 'best_t_ccd': best_t_ccd,
                 'nom_id_hash': nom_id_hash,
                 'best_id_hash': best_id_hash,

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -251,7 +251,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
         return {'nomdata': nom,
                 'bestdata': best,
                 'rolls': all_rolls,
-                'cone_stars': updated_cone_stars,
+                'cone_stars': cone_stars,
                 'roll_indep': False,
                 'comment': 'nominal is at max'}
     # check off nominal rolls in allowed range for a better catalog / temperature

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -36,6 +36,11 @@ warnings.filterwarnings(
 # Expand the last stage of guide selection in SAUSAGE to get some fainter stars to use them
 # to set a temperature
 mini_sausage.STAR_CHAR['Guide'][-1]['Inertial']['MagLimit'][1] = 11.0
+# Disable the "direct catalog search" for spoilers
+for acqstage in mini_sausage.STAR_CHAR['Acq']:
+    acqstage['SearchSettings']['DoSpoilerCheck'] = 0
+for guistage in mini_sausage.STAR_CHAR['Guide']:
+    guistage['SearchSettings']['DoSpoilerCheck'] = 0
 
 
 PLANNING_LIMIT = -11.5

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -711,8 +711,8 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
     displaycols = masked_table.colnames
     if not debug:
         displaycols = ['day', 'caldate', 'pitch',
-                       'nom_roll', 'nom_acq_tccd', 'nom_gui_5star', 'nom_gui_4star',
-                       'best_roll', 'best_acq_tccd', 'best_gui_5star', 'best_gui_4star', 'best_gui_3star', 'comment']
+                       'nom_roll', 'nom_t_ccd', 'nom_acq_tccd', 'nom_gui_4star',
+                       'best_roll', 'best_t_ccd', 'best_acq_tccd', 'best_gui_4star', 'comment']
     page = template.render(time_plot=tfig_html,
                            hist_plot='temperature_hist.png',
                            table=masked_table,

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -186,10 +186,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     Loop over possible roll range for this pitch and return best
     and nominal temperature/roll combinations
     """
-    best_roll = None
-    best_t_ccd = None
-    best_stars = None
-    best_n_acq = None
+
     nom_roll = Ska.Sun.nominal_roll(ra, dec, time=time)
     # Round nominal roll to the nearest half degree
     nom_roll = np.round(np.round(nom_roll * 2) / 2., 1)
@@ -258,6 +255,7 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
         off_nom_rolls = np.round(nom_roll) + plus_minus_rolls
     else:
         off_nom_rolls = [np.round(nom_roll)]
+    best_t_ccd = None
     best_is_max = False
     for roll in off_nom_rolls:
         q_pnt = calc_aca_from_targ((ra, dec, roll),
@@ -378,7 +376,6 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
 
     all_rolls = {}
     temps = {}
-    roll_indep_data = {}
     # loop over them to see which need data
     last_good_pitch = None
     last_good_day = None

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -417,8 +417,8 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
             nom_roll = Ska.Sun.nominal_roll(ra, dec, tday)
             temps[tday].update({
                 'nom_roll': nom_roll,
-                'nom_t_ccd': np.min([nom['guide_tccd1'], nom['acq_tccd']]),
-                'best_t_ccd': np.min([best['guide_tccd1'], best['acq_tccd']]),
+                'nom_t_ccd': np.min([nom['guide_tccd2'], nom['acq_tccd']]),
+                'best_t_ccd': np.min([best['guide_tccd2'], best['acq_tccd']]),
                 'nom_acq_tccd': nom['acq_tccd'],
                 'nom_gui_5star': nom['guide_tccd1'],
                 'nom_gui_4star': nom['guide_tccd2'],
@@ -445,8 +445,8 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         best = t_ccd_roll_data['bestdata']
         temps[tday].update({
                 'nom_roll': nom['roll'],
-                'nom_t_ccd': np.min([nom['guide_tccd1'], nom['acq_tccd']]),
-                'best_t_ccd': np.min([best['guide_tccd1'], best['acq_tccd']]),
+                'nom_t_ccd': np.min([nom['guide_tccd2'], nom['acq_tccd']]),
+                'best_t_ccd': np.min([best['guide_tccd2'], best['acq_tccd']]),
                 'nom_acq_tccd': nom['acq_tccd'],
                 'nom_gui_5star': nom['guide_tccd1'],
                 'nom_gui_4star': nom['guide_tccd2'],
@@ -686,7 +686,7 @@ def make_target_report(ra, dec, cycle, detector, too, y_offset, z_offset,
     displaycols = masked_table.colnames
     if not debug:
         displaycols = ['day', 'caldate', 'pitch',
-                       'nom_roll', 'nom_acq_tccd', 'nom_gui_5star',
+                       'nom_roll', 'nom_acq_tccd', 'nom_gui_5star', 'nom_gui_4star',
                        'best_roll', 'best_acq_tccd', 'best_gui_5star', 'best_gui_4star', 'best_gui_3star', 'comment']
     page = template.render(time_plot=tfig_html,
                            hist_plot='temperature_hist.png',

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -43,10 +43,10 @@ for guistage in mini_sausage.STAR_CHAR['Guide']:
     guistage['SearchSettings']['DoSpoilerCheck'] = 0
 
 
-PLANNING_LIMIT = -11.5
+PLANNING_LIMIT = -10.2
 EDGE_DIST = 30
 COLD_T_CCD = -21
-WARM_T_CCD = -7
+WARM_T_CCD = -5
 # explicitly disable MS filter
 set_acq_model_ms_filter(ms_enabled=False)
 

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -137,9 +137,9 @@ def get_rolldev(pitch):
 
 
 def select_stars(ra, dec, roll, cone_stars):
-    id_key = ("{:.5f}".format(ra),
-              "{:.5f}".format(dec),
-              "{:.5f}".format(roll))
+    id_key = ("{:.3f}".format(ra),
+              "{:.3f}".format(dec),
+              "{:.3f}".format(roll))
     updated_cone_stars = cone_stars
     if id_key not in CAT_CACHE:
         CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
@@ -148,8 +148,8 @@ def select_stars(ra, dec, roll, cone_stars):
 
 
 def select_ri_stars(ra, dec, cone_stars):
-    id_key = ("{:.5f}".format(ra),
-              "{:.5f}".format(dec))
+    id_key = ("{:.3f}".format(ra),
+              "{:.3f}".format(dec))
     updated_cone_stars = cone_stars
     if id_key not in RI_CAT_CACHE:
         RI_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_acq_stars(
@@ -158,9 +158,9 @@ def select_ri_stars(ra, dec, cone_stars):
 
 
 def select_guide_stars(ra, dec, roll, cone_stars):
-    id_key = ("{:.5f}".format(ra),
-              "{:.5f}".format(dec),
-              "{:.5f}".format(roll))
+    id_key = ("{:.3f}".format(ra),
+              "{:.3f}".format(dec),
+              "{:.3f}".format(roll))
     updated_cone_stars = cone_stars
     if id_key not in G_CAT_CACHE:
         G_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_guide_stars(
@@ -169,8 +169,8 @@ def select_guide_stars(ra, dec, roll, cone_stars):
 
 
 def select_ri_guide_stars(ra, dec, cone_stars):
-    id_key = ("{:.5f}".format(ra),
-              "{:.5f}".format(dec))
+    id_key = ("{:.3f}".format(ra),
+              "{:.3f}".format(dec))
     updated_cone_stars = cone_stars
     if id_key not in G_RI_CAT_CACHE:
         G_RI_CAT_CACHE[id_key], updated_cone_stars = mini_sausage.select_guide_stars(
@@ -314,6 +314,11 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
     CAT_CACHE.clear()
     global RI_CAT_CACHE
     RI_CAT_CACHE.clear()
+    global G_CAT_CACHE
+    G_CAT_CACHE.clear()
+    global G_RI_CAT_CACHE
+    G_RI_CAT_CACHE.clear()
+
 
     # Load any previously obtained results into cache
     t_ccd_file = os.path.join(outdir, "t_ccd_map.dat")
@@ -321,23 +326,41 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
         t_ccd = Table.read(t_ccd_file, format='ascii')
         for row in t_ccd:
             T_CCD_CACHE[row['key']] = (row['t_ccd'], row['n_acqs'])
+
     cat_file = os.path.join(outdir, "cat_map.dat")
     if os.path.exists(cat_file):
         cat = Table.read(cat_file, format="ascii")
         for row in cat:
-            CAT_CACHE[(row['ra'], row['dec'], row['roll'])] = Table.read(
+            CAT_CACHE[("{:.3f}".format(row['ra']),
+                       "{:.3f}".format(row['dec']),
+                       "{:.3f}".format(row['roll']))] = Table.read(
                 os.path.join(outdir, "{}_stars.dat".format(row['hash'])),
                 format='ascii')
     ri_cat_file = os.path.join(outdir, "ri_cat_map.dat")
     if os.path.exists(ri_cat_file):
         cat = Table.read(ri_cat_file, format="ascii")
         for row in cat:
-            RI_CAT_CACHE[(row['ra'], row['dec'])] = Table.read(
+            RI_CAT_CACHE[("{:.3f}".format(row['ra']),
+                          "{:.3f}".format(row['dec']))] = Table.read(
                 os.path.join(outdir, "{}_stars.dat".format(row['hash'])),
                 format='ascii')
-
     gcat_file = os.path.join(outdir, "gcat_map.dat")
+    if os.path.exists(gcat_file):
+        cat = Table.read(gcat_file, format="ascii")
+        for row in cat:
+            G_CAT_CACHE[("{:.3f}".format(row['ra']),
+                         "{:.3f}".format(row['dec']),
+                         "{:.3f}".format(row['roll']))] = Table.read(
+                os.path.join(outdir, "{}_stars.dat".format(row['hash'])),
+                format='ascii')
     g_ri_cat_file = os.path.join(outdir, "g_ri_cat_map.dat")
+    if os.path.exists(g_ri_cat_file):
+        cat = Table.read(g_ri_cat_file, format="ascii")
+        for row in cat:
+            G_RI_CAT_CACHE[("{:.3f}".format(row['ra']),
+                          "{:.3f}".format(row['dec']))] = Table.read(
+                os.path.join(outdir, "{}_stars.dat".format(row['hash'])),
+                format='ascii')
 
     start = DateTime(start)
     stop = DateTime(stop)

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -361,10 +361,17 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
     # set the agasc proper motion time to be in the middle of the
     # requested cycle
     lts_mid_time = start + (stop - start) / 2
-
+    # Pad the agasc cone extraction radius by a chunk and extra for pointing offsets
+    # and SI align
+    radius_pad_arcmin = 15 + np.sqrt((3 + (y_offset / 60.))**2
+                                     + (3 + (z_offset / 60.))**2)
+    radius = 1.5 + radius_pad_arcmin / 60.
     # Get stars in this field
-    print "fetching stars a {} {}".format(ra, dec)
-    cone_stars = agasc.get_agasc_cone(ra, dec, radius=3, date=lts_mid_time)
+    cone_stars = agasc.get_agasc_cone(ra, dec, radius=radius, date=lts_mid_time)
+    # Filter cone stars to just columns we need
+    cone_stars = cone_stars[['AGASC_ID', 'RA_PMCORR', 'DEC_PMCORR',
+                             'MAG_ACA', 'MAG_ACA_ERR', 'CLASS', 'POS_ERR',
+                             'ASPQ1', 'ASPQ2', 'ASPQ3', 'COLOR1']]
     if len(cone_stars) == 0:
         raise ValueError("No stars found in 3 degree radius of {} {}".format(ra, dec))
 

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -545,11 +545,11 @@ def t_ccd_for_attitude(ra, dec, cycle, detector, too, y_offset=0, z_offset=0,
     if len(g_ri_cats):
         Table(g_ri_cats)[['ra', 'dec', 'hash']].write(g_ri_cat_file, format='ascii')
 
-
+    catcols = ['AGASC_ID', 'RA_PMCORR', 'DEC_PMCORR', 'MAG_ACA', 'MAG_ACA_ERR', 'COLOR1', 'ASPQ1']
     for h in hashes:
         starfile = os.path.join(outdir, "{}_stars.dat".format(h))
-        hashes[h].write(starfile, format='ascii')
-        hashes[h].write(os.path.join(outdir, "{}.html".format(h)),
+        hashes[h][catcols].write(starfile, format='ascii')
+        hashes[h][catcols].write(os.path.join(outdir, "{}.html".format(h)),
                         format='jsviewer')
 
     return t_ccd_table, t_ccd_roll

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -194,9 +194,12 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     # check off nominal rolls in allowed range for a better catalog / temperature
     roll_dev = get_rolldev(pitch)
     d_roll = 1.0
-    plus_minus_rolls = np.concatenate([[-r, r] for r in
-                                       np.arange(d_roll, roll_dev, d_roll)])
-    off_nom_rolls = np.round(nom_roll) + plus_minus_rolls
+    if roll_dev > d_roll:
+        plus_minus_rolls = np.concatenate([[-r, r] for r in
+                                           np.arange(d_roll, roll_dev, d_roll)])
+        off_nom_rolls = np.round(nom_roll) + plus_minus_rolls
+    else:
+        off_nom_rolls = [np.round(nom_roll)]
     best_is_max = False
     for roll in off_nom_rolls:
         q_pnt = calc_aca_from_targ((ra, dec, roll),

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -191,6 +191,8 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     best_stars = None
     best_n_acq = None
     nom_roll = Ska.Sun.nominal_roll(ra, dec, time=time)
+    # Round nominal roll to the nearest half degree
+    nom_roll = np.round(np.round(nom_roll * 2) / 2., 1)
     chipx, chipy, chip_id = get_target_aimpoint(time, cycle, detector, too)
     aca_offset_y, aca_offset_z = get_aca_offsets(
         detector, chip_id, chipx, chipy, time, PLANNING_LIMIT - 2)

--- a/aca_lts_eval.py
+++ b/aca_lts_eval.py
@@ -231,10 +231,10 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
     acq_sel = select_stars(ra_pnt, dec_pnt, nom_roll, cone_stars)
     acq_stars = acq_sel[0]
     guide_sel = select_guide_stars(ra_pnt, dec_pnt, nom_roll, acq_sel[1])
-    cone_stars = guide_sel[1]
-    acq_tccd, nacq = max_temp(time=time, stars=acq_sel[0])
     guide_stars = guide_sel[0]
     guide_stars.sort('MAG_ACA')
+    cone_stars = guide_sel[1]
+    acq_tccd, nacq = max_temp(time=time, stars=acq_stars)
     guide_tccd = t_lose_star(guide_stars[-1]['MAG_ACA']) if len(guide_stars) == 5 else -21
     t_ccd = np.min([acq_tccd, guide_tccd])
     nom = {'roll': nom_roll,
@@ -273,9 +273,9 @@ def get_t_ccd_roll(ra, dec, cycle, detector, too, y_offset, z_offset, pitch, tim
         acq_sel = select_stars(ra_pnt, dec_pnt, roll, cone_stars)
         acq_stars = acq_sel[0]
         guide_sel = select_guide_stars(ra_pnt, dec_pnt, roll, acq_sel[1])
-        acq_tccd, nacq = max_temp(time=time, stars=guide_sel[1])
         guide_stars = guide_sel[0]
         guide_stars.sort('MAG_ACA')
+        acq_tccd, nacq = max_temp(time=time, stars=acq_stars)
         guide_tccd = t_lose_star(guide_stars[-1]['MAG_ACA']) if len(guide_stars) == 5 else -21
         t_ccd = np.min([acq_tccd, guide_tccd])
         all_rolls[roll] = t_ccd

--- a/check_sausage.py
+++ b/check_sausage.py
@@ -7,7 +7,7 @@ from kadi import events
 from astropy.table import Table
 import aca_required_temp
 
-def check_obs(obsid):
+def check_obs_acqs(obsid):
     try:
         sc = mica.starcheck.get_starcheck_catalog(obsid)
     except:
@@ -25,67 +25,116 @@ def check_obs(obsid):
     roll = sc['obs']['point_roll']
     cone_stars = agasc.get_agasc_cone(ra, dec, radius=1.2,
                                       date=sc['obs']['mp_starcat_time'],
-                                      agasc_file='/proj/sot/ska/jeanproj/git/agasc/miniagasc.h5')
+                                      agasc_file='/proj/sot/ska/data/agasc/agasc1p6.h5')
     acqs = sc['cat'][(sc['cat']['type'] == 'BOT') | (sc['cat']['type'] == 'ACQ')]
     acq_pass = [re.sub('g\d{1}', '', ap) for ap in acqs['pass']]
     acq_manual = np.array([re.search('X', ap) is not None for ap in acq_pass])
     acq_pass = [re.sub('gX', '', ap) for ap in acq_pass]
     acq_pass = [re.sub('aX', '', ap) for ap in acq_pass]
-    acq_pass = np.array([re.sub('^$', 'a1', ap) for ap in acq_pass])
+    acq_pass = [re.sub('--', '', ap) for ap in acq_pass]
+    acq_pass = [re.sub('^$', 'a1', ap) for ap in acq_pass]
+    acq_pass = np.array([int(re.sub('a', '', ap)) for ap in acq_pass])
+
+
+    guis = sc['cat'][(sc['cat']['type'] == 'BOT') | (sc['cat']['type'] == 'GUI')]
+    gui_pass = [re.sub('a\d{1}', '', ap) for ap in guis['pass']]
+    gui_manual = np.array([re.search('X', ap) is not None for ap in gui_pass])
+    gui_pass = [re.sub('gX', '', ap) for ap in gui_pass]
+    gui_pass = [re.sub('aX', '', ap) for ap in gui_pass]
+    gui_pass = [re.sub('--', '', ap) for ap in gui_pass]
+    gui_pass = [re.sub('^$', 'g1', ap) for ap in gui_pass]
+    gui_pass = np.array([int(re.sub('g', '', ap)) for ap in gui_pass])
+
 
     mini_sausage.set_dither(np.max([sc['obs']['dither_y_amp'], sc['obs']['dither_z_amp'], 8.0]))
     mini_sausage.set_manvr_error(sc['manvr'][-1]['slew_err_arcsec'])
-    select, all_stars = mini_sausage.select_stars(ra, dec, roll, cone_stars)
-    all_stars['starcheck'] = False
+    select_acqs, all_stars = mini_sausage.select_acq_stars(ra, dec, roll, n=len(acqs), cone_stars=cone_stars)
+    select_guis, all_stars = mini_sausage.select_guide_stars(ra, dec, roll, n=len(guis), cone_stars=all_stars)
+    all_stars['starcheck_acq'] = False
     for star in acqs:
-        all_stars['starcheck'][all_stars['AGASC_ID'] == star['id']] = True
+        all_stars['starcheck_acq'][all_stars['AGASC_ID'] == star['id']] = True
+    all_stars['starcheck_gui'] = False
+    for star in guis:
+        all_stars['starcheck_gui'][all_stars['AGASC_ID'] == star['id']] = True
+
     sc_t_ccd, sc_n_acq = aca_required_temp.max_temp(time=sc['obs']['mp_starcat_time'],
-                                                stars=all_stars[all_stars['starcheck']])
+                                                stars=all_stars[all_stars['starcheck_acq']])
     ms_t_ccd, ms_n_acq = aca_required_temp.max_temp(time=sc['obs']['mp_starcat_time'],
-                                                stars=select)
+                                                stars=select_acqs)
     print obsid, "starcheck {}".format(sc_t_ccd), "manual? ", np.any(acq_manual), "mine {}".format(ms_t_ccd)
     obs = {'obsid': obsid,
            'sc_t_ccd': sc_t_ccd,
-           'sc_had_manual': np.any(acq_manual),
+           'sc_acq_manual': np.any(acq_manual),
+           'sc_gui_manual': np.any(gui_manual),
            'ms_t_ccd': ms_t_ccd,
-           'total': len(acqs),
-           'new': 0}
-
+           'acq_total': len(acqs),
+           'gui_total': len(guis),
+           'acq_match': 0,
+           'gui_match': 0,
+           'gui_p_match': 0,
+           'gui_sc_avgmag': np.mean(guis['mag']),
+           'gui_ms_avgmag': np.mean(select_guis['MAG_ACA']),
+           'gui_sc_nstage': np.max(gui_pass),
+           'gui_extra': 0
+           'dither': np.max([sc['obs']['dither_y_amp'], sc['obs']['dither_z_amp'], 8.0]),
+           }
     for star in acqs:
-        if star['id'] in select['AGASC_ID']:
-            obs['new'] += 1
-    for p in [1, 2, 3, 4]:
-        sc_acqs_for_p = acqs[acq_pass == 'a{}'.format(p)]
-        obs['sc_n_{}'.format(p)] = len(sc_acqs_for_p)
-        new_acqs_for_p = select[(select['stage'] == p)]
-        obs['new_n_{}'.format(p)] = 0
-        for star in sc_acqs_for_p:
-            if star['id'] in new_acqs_for_p['AGASC_ID']:
-                obs['new_n_{}'.format(p)] += 1
-        obs['extra_n_{}'.format(p)] = len(new_acqs_for_p) - len(sc_acqs_for_p)
+        if star['id'] in select_acqs['AGASC_ID']:
+            obs['acq_match'] += 1
+    for star in guis:
+        if star['id'] in select_guis['AGASC_ID']:
+            obs['gui_match'] += 1
+    for star, p in zip(guis, gui_pass):
+        if star['id'] in all_stars[all_stars['Guide_stage'] == int(p)]['AGASC_ID']:
+            obs['gui_p_match'] +=1
+
+
+
+#    for p in range(1, np.max([np.max(acq_pass), np.max(select_acq['Acq_stage'])]) + 1):
+#        sc_acqs_for_p = acqs[acq_pass == p]
+#        obs['sc_n_{}'.format(p)] = len(sc_acqs_for_p)
+#        new_acqs_for_p = select[(select_acq['Acq_stage'] == p)]
+#        obs['new_n_{}'.format(p)] = 0
+#        for star in sc_acqs_for_p:
+#            if star['id'] in new_acqs_for_p['AGASC_ID']:
+#                obs['new_n_{}'.format(p)] += 1
+#        obs['extra_n_{}'.format(p)] = len(new_acqs_for_p) - len(sc_acqs_for_p)
+#    for p in range(1, np.max([np.max(gui_pass), np.max(select['Acq_stage'])]) + 1):
+#        sc_acqs_for_p = acqs[acq_pass == p]
+#        obs['sc_n_{}'.format(p)] = len(sc_acqs_for_p)
+#        new_acqs_for_p = select[(select['Gui_stage'] == p)]
+#        obs['new_n_{}'.format(p)] = 0
+#        for star in sc_acqs_for_p:
+#            if star['id'] in new_acqs_for_p['AGASC_ID']:
+#                obs['new_n_{}'.format(p)] += 1
+#        obs['extra_n_{}'.format(p)] = len(new_acqs_for_p) - len(sc_acqs_for_p)
+#
+
+
+    print(obs)
     return obs
 
 
 check = []
 
-for kadi_obs in events.obsids.filter('2013:001', '2015:100'):
-#for obsid in [15057]:
+for kadi_obs in events.obsids.filter('2017:110', '2017:200'):
+#for obsid in [19864]:
     print kadi_obs
     obsid = kadi_obs.obsid
 
-    check_table = check_obs(obsid)
+    check_table = check_obs_acqs(obsid)
     if check_table is not None:
         check.append(check_table)
 
 
-check = Table(check)['obsid',
-                     'sc_t_ccd', 'ms_t_ccd',
-                     'total', 'new', 'sc_had_manual',
-                     'sc_n_1', 'sc_n_2', 'sc_n_3', 'sc_n_4',
-                     'new_n_1', 'new_n_2', 'new_n_3', 'new_n_4',
-                     'extra_n_1', 'extra_n_2', 'extra_n_3', 'extra_n_4']
-
-check.write("table.dat", format="ascii.tab")
-
+#check = Table(check)['obsid',
+#                     'sc_t_ccd', 'ms_t_ccd',
+#                     'total', 'new', 'sc_had_manual',
+#                     'sc_n_1', 'sc_n_2', 'sc_n_3', 'sc_n_4',
+#                     'new_n_1', 'new_n_2', 'new_n_3', 'new_n_4',
+#                     'extra_n_1', 'extra_n_2', 'extra_n_3', 'extra_n_4']
+#
+#check.write("ntable.dat", format="ascii.tab")
+#
 
 

--- a/make_obsid_files.py
+++ b/make_obsid_files.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import os
+import numpy as np
+from Ska.DBI import DBI
+from astropy.table import Table
+from Chandra.Time import DateTime
+import astropy.units as u
+from astropy.coordinates import SkyCoord, search_around_sky
+
+
+N_FILES = 6
+
+
+db = DBI(dbi='sybase', server='sqlsao', database='axafocat', user='aca_ops')
+query = """SELECT t.obsid, t.ra, t.dec,
+t.type, t.y_det_offset as y_offset, t.z_det_offset as z_offset, 
+t.approved_exposure_time, t.instrument, t.grating, t.obs_ao_str, p.ao_str
+FROM target t
+right join prop_info p on t.ocat_propid = p.ocat_propid
+WHERE
+(t.soe_st_sched_date is not null
+AND t.soe_st_sched_date >= '2011'
+AND NOT(t.ra = 0 AND t.dec = 0)
+AND NOT(t.ra IS NULL OR t.dec IS NULL))
+ORDER BY t.obsid"""
+
+targets = Table(db.fetchall(query))
+db.conn.close()
+del db
+
+# Remove target attitudes within 1 arcmin
+targ_coord = SkyCoord(targets['ra'], targets['dec'], unit='deg')
+# Use search_around_sky to get matches from the list into itself
+idx1, idx2, dist, dist3d = search_around_sky(targ_coord, targ_coord, seplimit=1 * u.arcmin)
+# Exactly matching oneself is not a duplicate
+itself = idx1 == idx2
+# In the indices into each list, if the index in idx1 is greater than the index in idx2
+# the target attitude is the 2nd or nth occurrence of the attitudes and is a duplicate
+dups = idx1[~itself][idx1[~itself] > idx2[~itself]]
+targets['duplicate'] = False
+targets['duplicate'][dups] = True
+targets = targets[targets['duplicate'] == False]
+
+# I don't see an easy way to split a table so, split an index array
+idx_split = np.array_split(np.arange(len(targets)), N_FILES)
+for i, s in enumerate(idx_split):
+    targets[s].write("obsids_{}.dat".format(i), format='ascii')
+
+
+
+

--- a/make_reports.py
+++ b/make_reports.py
@@ -36,6 +36,9 @@ def get_options():
                         help="Start time for roll/temp checks.  Defaults to ~Aug of previous cycle")
     parser.add_argument("--stop",
                         help="Stop time for roll/temp checks.  Default to March past end of cycle.")
+    parser.add_argument("--daystep",
+                        default=1,
+                        type=int)
     parser.add_argument("--redo",
                         action='store_true',
                         help="Redo processing even if complete and up-to-date")
@@ -114,6 +117,7 @@ for t in targets:
                                          t['y_offset'], t['z_offset'],
                                          start=start,
                                          stop=stop,
+                                         daystep=opt.daystep,
                                          obsdir=obsdir,
                                          obsid=t['obsid'],
                                          debug=False,

--- a/make_reports.py
+++ b/make_reports.py
@@ -183,7 +183,7 @@ for t in targets:
         report_table = Table(report)['obsid', 'obsdir', 'ra', 'dec', 'y_offset', 'z_offset',
                                      'max_nom_t_ccd', 'min_nom_t_ccd',
                                      'max_best_t_ccd', 'min_best_t_ccd', 'frac_nom_ok', 'frac_best_ok']
-        report_table.sort('min_nom_t_ccd')
+        report_table.sort('frac_best_ok')
         report_table.write(os.path.join(OUTDIR, "target_table.dat"),
                            format="ascii.fixed_width_two_line")
 
@@ -191,7 +191,7 @@ for t in targets:
 report_table = Table(report)['obsid', 'obsdir', 'ra', 'dec', 'y_offset', 'z_offset',
                              'max_nom_t_ccd', 'min_nom_t_ccd',
                              'max_best_t_ccd', 'min_best_t_ccd', 'frac_nom_ok', 'frac_best_ok']
-report_table.sort('min_nom_t_ccd')
+report_table.sort('frac_best_ok')
 report_table.write(os.path.join(OUTDIR, "target_table.dat"),
                    format="ascii.fixed_width_two_line")
 

--- a/make_reports.py
+++ b/make_reports.py
@@ -20,7 +20,7 @@ warnings.filterwarnings(
     message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
     category=DeprecationWarning)
 
-RELEASE_VERSION = '1.5.0'
+RELEASE_VERSION = '2.0'
 
 def get_options():
     import argparse

--- a/make_reports.py
+++ b/make_reports.py
@@ -141,6 +141,10 @@ for t in targets:
                                          debug=False,
                                          redo=redo)
         if t_ccd_table is not None:
+            nom = t_ccd_table['nom_t_ccd'][~np.isnan(t_ccd_table['nom_t_ccd'])]
+            best = t_ccd_table['best_t_ccd'][~np.isnan(t_ccd_table['best_t_ccd'])]
+            frac_nom_ok = np.count_nonzero(nom >= PLANNING_LIMIT) * 1.0 / len(nom)
+            frac_best_ok = np.count_nonzero(best >= PLANNING_LIMIT) * 1.0 / len(best)
             report.append({'obsid': t['obsid'],
                            'obsdir': obsdir,
                            'ra': t['ra'],
@@ -151,6 +155,8 @@ for t in targets:
                            'min_nom_t_ccd': np.nanmin(t_ccd_table['nom_t_ccd']),
                            'max_best_t_ccd': np.nanmax(t_ccd_table['best_t_ccd']),
                            'min_best_t_ccd': np.nanmin(t_ccd_table['best_t_ccd']),
+                           'frac_nom_ok': frac_nom_ok,
+                           'frac_best_ok': frac_best_ok,
                            })
 
     else:
@@ -166,6 +172,9 @@ for t in targets:
                        'min_nom_t_ccd': previous_record['min_nom_t_ccd'],
                        'max_best_t_ccd': previous_record['max_best_t_ccd'],
                        'min_best_t_ccd': previous_record['min_best_t_ccd'],
+                       'frac_nom_ok': previous_record['frac_nom_ok'],
+                       'frac_best_ok': previous_record['frac_best_ok'],
+
                        })
 
 
@@ -173,7 +182,7 @@ for t in targets:
         # Write out the text file on every loop/target if incremental option set
         report_table = Table(report)['obsid', 'obsdir', 'ra', 'dec', 'y_offset', 'z_offset',
                                      'max_nom_t_ccd', 'min_nom_t_ccd',
-                                     'max_best_t_ccd', 'min_best_t_ccd']
+                                     'max_best_t_ccd', 'min_best_t_ccd', 'frac_nom_ok', 'frac_best_ok']
         report_table.sort('min_nom_t_ccd')
         report_table.write(os.path.join(OUTDIR, "target_table.dat"),
                            format="ascii.fixed_width_two_line")
@@ -181,7 +190,7 @@ for t in targets:
 
 report_table = Table(report)['obsid', 'obsdir', 'ra', 'dec', 'y_offset', 'z_offset',
                              'max_nom_t_ccd', 'min_nom_t_ccd',
-                             'max_best_t_ccd', 'min_best_t_ccd']
+                             'max_best_t_ccd', 'min_best_t_ccd', 'frac_nom_ok', 'frac_best_ok']
 report_table.sort('min_nom_t_ccd')
 report_table.write(os.path.join(OUTDIR, "target_table.dat"),
                    format="ascii.fixed_width_two_line")
@@ -217,7 +226,10 @@ formats = {
     'max_nom_t_ccd': '%5.2f',
     'min_nom_t_ccd': '%5.2f',
     'max_best_t_ccd': '%5.2f',
-    'min_best_t_ccd': '%5.2f'}
+    'min_best_t_ccd': '%5.2f',
+    'frac_nom_ok': '%7.4f',
+    'frac_best_ok': '%7.4f'}
+
 page = template.render(table=report_table,
                        formats=formats,
                        planning_limit=PLANNING_LIMIT,

--- a/make_reports.py
+++ b/make_reports.py
@@ -48,6 +48,8 @@ def get_options():
     parser.add_argument("--incremental",
                        action='store_true',
                        help="Write out table as processed (good for recovery of long processing)")
+    parser.add_argument("--only-existing",
+                       action="store_true")
     opt = parser.parse_args()
     return opt
 
@@ -113,6 +115,8 @@ update_cnt = 0
 
 for t in targets:
     obsdir = os.path.join(OUTDIR, 'obs{:05d}'.format(t['obsid']))
+    if not os.path.exists(obsdir) and opt.only_existing == True:
+        continue
     if not os.path.exists(obsdir):
         os.makedirs(obsdir)
     redo = check_update_needed(t, obsdir) or opt.redo

--- a/make_reports.py
+++ b/make_reports.py
@@ -29,9 +29,9 @@ def get_options():
     parser.add_argument("--out",
                        default="out")
     parser.add_argument("--cycle",
-                        default=18)
+                        default=19)
     parser.add_argument("--planning-limit",
-                        default=-11.5,
+                        default=-10.2,
                         type=float)
     parser.add_argument("--start",
                         help="Start time for roll/temp checks.  Defaults to ~Aug of previous cycle")

--- a/make_reports.py
+++ b/make_reports.py
@@ -11,6 +11,7 @@ from Ska.DBI import DBI
 from astropy.table import Table
 from Chandra.Time import DateTime
 from aca_lts_eval import check_update_needed, make_target_report
+import chandra_aca
 
 import warnings
 # Ignore known numexpr.necompiler and table.conditions warning
@@ -200,6 +201,7 @@ page = template.render(table=report_table,
                        start=start.fits,
                        stop=stop.fits,
                        gitlabel=gitlabel,
+                       chandra_aca=chandra_aca.__version__,
                        release=RELEASE_VERSION,
                        label='ACA Evaluation of Targets')
 f = open(os.path.join(OUTDIR, 'index.html'), 'w')

--- a/make_reports.py
+++ b/make_reports.py
@@ -40,6 +40,8 @@ def get_options():
     parser.add_argument("--daystep",
                         default=1,
                         type=int)
+    parser.add_argument("--obsid-file",
+                        help="File with list of obsids to process")
     parser.add_argument("--redo",
                         action='store_true',
                         help="Redo processing even if complete and up-to-date")
@@ -76,6 +78,14 @@ db.conn.close()
 del db
 targets.write(os.path.join(OUTDIR, 'requested_targets.txt'),
               format='ascii.fixed_width_two_line')
+
+
+if opt.obsid_file is not None:
+    targets['requested'] = False
+    obsids = Table.read(opt.obsid_file, format='ascii')['obsid']
+    for obsid in obsids:
+        targets['requested'][targets['obsid'] == int(obsid)] = True
+    targets = targets[targets['requested'] == True]
 
 
 stop = DateTime('{}-03-15'.format(2000 + CYCLE))

--- a/make_reports.py
+++ b/make_reports.py
@@ -31,7 +31,8 @@ def get_options():
     parser.add_argument("--cycle",
                         default=18)
     parser.add_argument("--planning-limit",
-                        default=-11.5)
+                        default=-11.5,
+                        type=float)
     parser.add_argument("--start",
                         help="Start time for roll/temp checks.  Defaults to ~Aug of previous cycle")
     parser.add_argument("--stop",

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -1,20 +1,21 @@
 import warnings
-# Ignore known numexpr.necompiler and table.conditions warning
-warnings.filterwarnings(
-    'ignore',
-    message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
-    category=DeprecationWarning)
 from itertools import count
 
 import agasc
 import numpy as np
-from astropy.table import Table, Column
 from astropy.coordinates import SkyCoord, search_around_sky
 import astropy.units as u
 from Quaternion import Quat
 from Ska.quatutil import radec2yagzag
 import chandra_aca
 import json
+
+# Ignore known numexpr.necompiler and table.conditions warning
+warnings.filterwarnings(
+    'ignore',
+    message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
+    category=DeprecationWarning)
+
 
 matlab_char = json.load(open('characteristics.json'))
 STAR_CHAR = matlab_char['FOT_MATLAB_Tools_Characteristics']['Stars']
@@ -92,10 +93,8 @@ def check_mag(cone_stars, opt, label):
 
 def check_mag_spoilers(cone_stars, ok, opt):
     stype = opt['Type']
-    magOneSigError = cone_stars['mag_one_sig_err']
     stderr2 = cone_stars['mag_one_sig_err2']
     fidpad = fieldErrorPad * ARC_2_PIX
-    minsep = opt['Spoiler']['MinSep'] + fidpad
     maxsep = opt['Spoiler']['MaxSep'] + fidpad
     intercept = opt['Spoiler']['Intercept'] + fidpad
     spoilslope = opt['Spoiler']['Slope']
@@ -103,7 +102,6 @@ def check_mag_spoilers(cone_stars, ok, opt):
     magdifflim = opt['Spoiler']['MagDiffLimit']
     if magdifflim == '-_Inf_':
         magdifflim = -1 * np.inf
-    mag = cone_stars['MAG_ACA']
     mag_col = 'mag_spoiled_{}_{}'.format(nSigma, stype)
     mag_spoil_check = 'mag_spoil_check_{}_{}'.format(nSigma, stype)
     if mag_col in cone_stars.columns:

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -329,14 +329,12 @@ def select_stage_stars(ra, dec, roll, cone_stars, roll_indep=False, stype='Acq')
                   | (cone_stars['ASPQ3'] < np.min(opt['Inertial']['ASPQ3Lim'])))
     cone_stars['bad_aspq3_{}'.format(stype)] = bad_aspq3
 
-    variable = cone_stars['VAR'] > 9999
-    cone_stars['variable'] = variable
 
     nonstellar = cone_stars['CLASS'] != 0
     cone_stars['nonstellar'] = nonstellar
 
     not_bad = (~offchip & ~outofbounds & ~bad_mag_error & ~bad_pos_error
-                & ~nonstellar & ~bad_aspq1 & ~bad_aspq2 & ~bad_aspq3 & ~variable)
+                & ~nonstellar & ~bad_aspq1 & ~bad_aspq2 & ~bad_aspq3)
 
     if roll_indep:
         inner_ring = row**2 + col**2 < 480**2

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -77,7 +77,7 @@ def check_off_chips(cone_stars, opt):
     return chip_edge_dist, fov_edge_dist, offchip, outofbounds
 
 
-def check_mag(cone_stars, opt):
+def check_mag(cone_stars, opt, label):
     magOneSigError = cone_stars['mag_one_sig_err']
     mag = cone_stars['MAG_ACA']
     magNSig = opt['Spoiler']['SigErrMultiplier'] * magOneSigError
@@ -86,9 +86,9 @@ def check_mag(cone_stars, opt):
     too_dim = ((mag + magNSig + opt['Inertial']['MagErrSyst'])
                > np.max(opt['Inertial']['MagLimit']))
     nomag = mag == -9999
-    cone_stars['too_bright'] = too_bright
-    cone_stars['too_dim'] = too_dim
-    cone_stars['nomag'] = nomag
+    cone_stars['too_bright_{}'.format(label)] = too_bright
+    cone_stars['too_dim_{}'.format(label)] = too_dim
+    cone_stars['nomag_{}'.format(label)] = nomag
     return ~too_bright & ~too_dim & ~nomag
 
 
@@ -106,8 +106,8 @@ def check_mag_spoilers(cone_stars, ok, opt):
     if magdifflim == '-_Inf_':
         magdifflim = -1 * np.inf
     mag = cone_stars['MAG_ACA']
-    mag_col = 'mag_spoiled_{}'.format(nSigma)
-    mag_spoil_check = 'mag_spoil_check_{}'.format(nSigma)
+    mag_col = 'mag_spoiled_{}_{}'.format(nSigma, stype)
+    mag_spoil_check = 'mag_spoil_check_{}_{}'.format(nSigma, stype)
     if mag_col in cone_stars.columns:
         # if ok for stage and not previously mag spoiler checked for this
         # nsigma
@@ -215,9 +215,9 @@ def check_column(cone_stars, not_bad, opt, chip_pos):
     pass
 
 
-def check_stage(cone_stars, not_bad, opt):
+def check_stage(cone_stars, not_bad, opt, label):
     stype = opt['Type']
-    mag_ok = check_mag(cone_stars, opt)
+    mag_ok = check_mag(cone_stars, opt, label)
     ok = mag_ok & not_bad
     if not np.any(ok):
         return ok

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -26,7 +26,6 @@ RAD_2_PIX = 180/np.pi*3600*ARC_2_PIX
 
 DITHER = 8
 MANVR_ERROR = 60
-#fixedErrorPad = DITHER + MANVR_ERROR
 fieldErrorPad = 0
 
 
@@ -37,9 +36,7 @@ def set_dither(dither):
 
 def set_manvr_error(manvr_error):
     global MANVR_ERROR
-    #global fixedErrorPad
     MANVR_ERROR = manvr_error
-    #fixedErrorPad = DITHER + MANVR_ERROR
 
 
 def fixedErrorPad(stype):

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -84,9 +84,9 @@ def check_mag(cone_stars, opt, label):
     too_dim = ((mag + magNSig + opt['Inertial']['MagErrSyst'])
                > np.max(opt['Inertial']['MagLimit']))
     nomag = mag == -9999
-    cone_stars['too_bright_{}'.format(label)] = too_bright
-    cone_stars['too_dim_{}'.format(label)] = too_dim
-    cone_stars['nomag_{}'.format(label)] = nomag
+    #cone_stars['too_bright_{}'.format(label)] = too_bright
+    #cone_stars['too_dim_{}'.format(label)] = too_dim
+    #cone_stars['nomag_{}'.format(label)] = nomag
     return ~too_bright & ~too_dim & ~nomag
 
 
@@ -256,7 +256,7 @@ def check_stage(cone_stars, not_bad, opt, label):
     box_size_arc[box_size_arc > maxBoxArc] = maxBoxArc
     cone_stars['box_size_arc_{}'.format(stype)] = box_size_arc
     bad_box = starBox < (minBoxArc * ARC_2_PIX)
-    cone_stars['bad_box_{}'.format(stype)] = bad_box
+    #cone_stars['bad_box_{}'.format(stype)] = bad_box
 #    if opt['SearchSettings']['DoColumnRegisterCheck']:
 #        badcolumn = check_column(cone_stars, ok & ~mag_spoiled & ~bad_dist, opt, chip_pos)
 #        ok = ok & ~badcolumn
@@ -301,8 +301,8 @@ def select_stage_stars(ra, dec, roll, cone_stars, roll_indep=False, stype='Acq')
 
     # none of these appear stage dependent, but they could be type (guide/acq) dependent
     chip_edge_dist, fov_edge_dist, offchip, outofbounds = check_off_chips(cone_stars, opt)
-    cone_stars['offchip_{}'.format(stype)] = offchip
-    cone_stars['outofbounds_{}'.format(stype)] = outofbounds
+    #cone_stars['offchip_{}'.format(stype)] = offchip
+    #cone_stars['outofbounds_{}'.format(stype)] = outofbounds
     cone_stars['chip_edge_dist_{}'.format(stype)] = chip_edge_dist
     cone_stars['fov_edge_dist_{}'.format(stype)] = fov_edge_dist
     if roll_indep:
@@ -310,26 +310,26 @@ def select_stage_stars(ra, dec, roll, cone_stars, roll_indep=False, stype='Acq')
         cone_stars['fov_edge_dist_{}'.format(stype)] = 2500
 
     bad_mag_error = cone_stars['MAG_ACA_ERR'] > opt['Inertial']['MagErrorTol']
-    cone_stars['bad_mag_error_{}'.format(stype)] = bad_mag_error
+    #cone_stars['bad_mag_error_{}'.format(stype)] = bad_mag_error
 
     bad_pos_error = cone_stars['POS_ERR'] > opt['Inertial']['PosErrorTol']
-    cone_stars['bad_pos_error_{}'.format(stype)] = bad_pos_error
+    #cone_stars['bad_pos_error_{}'.format(stype)] = bad_pos_error
 
     bad_aspq1 = ((cone_stars['ASPQ1'] > np.max(opt['Inertial']['ASPQ1Lim']))
                   | (cone_stars['ASPQ1'] < np.min(opt['Inertial']['ASPQ1Lim'])))
-    cone_stars['bad_aspq1_{}'.format(stype)] = bad_aspq1
+    #cone_stars['bad_aspq1_{}'.format(stype)] = bad_aspq1
 
     bad_aspq2 = ((cone_stars['ASPQ2'] > np.max(opt['Inertial']['ASPQ2Lim']))
                   | (cone_stars['ASPQ2'] < np.min(opt['Inertial']['ASPQ2Lim'])))
-    cone_stars['bad_aspq2_{}'.format(stype)] = bad_aspq2
+    #cone_stars['bad_aspq2_{}'.format(stype)] = bad_aspq2
 
     bad_aspq3 = ((cone_stars['ASPQ3'] > np.max(opt['Inertial']['ASPQ3Lim']))
                   | (cone_stars['ASPQ3'] < np.min(opt['Inertial']['ASPQ3Lim'])))
-    cone_stars['bad_aspq3_{}'.format(stype)] = bad_aspq3
+    #cone_stars['bad_aspq3_{}'.format(stype)] = bad_aspq3
 
 
     nonstellar = cone_stars['CLASS'] != 0
-    cone_stars['nonstellar'] = nonstellar
+    #cone_stars['nonstellar'] = nonstellar
 
     not_bad = (~offchip & ~outofbounds & ~bad_mag_error & ~bad_pos_error
                 & ~nonstellar & ~bad_aspq1 & ~bad_aspq2 & ~bad_aspq3)

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -217,14 +217,17 @@ def check_stage(cone_stars, not_bad, opt, label):
     if not np.any(ok):
         return ok
     nSigma = opt['Spoiler']['SigErrMultiplier']
-    mag_check_col = 'mag_spoil_check_{}_{}'.format(nSigma, stype)
-    if mag_check_col not in cone_stars.columns:
-        cone_stars[mag_check_col] = np.zeros_like(not_bad)
-        cone_stars['mag_spoiled_{}_{}'.format(nSigma, stype)] = np.zeros_like(not_bad)
-    mag_spoiled, checked= check_mag_spoilers(cone_stars, ok, opt)
-    cone_stars[mag_check_col] = cone_stars[mag_check_col] | checked
-    cone_stars['mag_spoiled_{}_{}'.format(nSigma, stype)] = (
-        cone_stars['mag_spoiled_{}_{}'.format(nSigma, stype)] | mag_spoiled)
+    mag_spoiled = ~ok.copy()
+    if ('DoSpoilerCheck' not in opt['SearchSettings']) or (opt['SearchSettings']['DoSpoilerCheck'] == 1):
+
+        mag_check_col = 'mag_spoil_check_{}_{}'.format(nSigma, stype)
+        if mag_check_col not in cone_stars.columns:
+            cone_stars[mag_check_col] = np.zeros_like(not_bad)
+            cone_stars['mag_spoiled_{}_{}'.format(nSigma, stype)] = np.zeros_like(not_bad)
+        mag_spoiled, checked= check_mag_spoilers(cone_stars, ok, opt)
+        cone_stars[mag_check_col] = cone_stars[mag_check_col] | checked
+        cone_stars['mag_spoiled_{}_{}'.format(nSigma, stype)] = (
+            cone_stars['mag_spoiled_{}_{}'.format(nSigma, stype)] | mag_spoiled)
     bad_pix_dist = check_bad_pixels(cone_stars, ok & ~mag_spoiled, opt)
     cone_stars['bad_pix_dist_{}'.format(stype)] = bad_pix_dist
 
@@ -260,7 +263,7 @@ def check_stage(cone_stars, not_bad, opt, label):
 #    if opt['SearchSettings']['DoBminusVCheck']:
 #        badbv = check_bv(cone_stars, ok & ~mag_spoiled & ~bad_dist)
 #        ok = ok & ~badbv
-    return ok & ~mag_spoiled & ~bad_box
+    return ok & ~bad_box & ~mag_spoiled
 
 
 def get_mag_errs(cone_stars, opt):

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -356,7 +356,7 @@ def select_stage_stars(ra, dec, roll, cone_stars, roll_indep=False, stype='Acq')
 
 def select_acq_stars(ra, dec, roll, n=8, cone_stars=None, roll_indep=False, date=None):
     if cone_stars is None:
-        cone_stars = agasc.get_agasc_cone(ra, dec, radius=3, date=date, agasc_file='/proj/sot/ska/data/agasc/agasc1p6.h5')
+        cone_stars = agasc.get_agasc_cone(ra, dec, radius=2, date=date, agasc_file='/proj/sot/ska/data/agasc/agasc1p6.h5')
     selected = select_stage_stars(ra, dec, roll, cone_stars,
                                   roll_indep=roll_indep, stype='Acq')
     selected['box_delta'] = 240 - selected['box_size_arc_Acq']
@@ -369,7 +369,7 @@ def select_acq_stars(ra, dec, roll, n=8, cone_stars=None, roll_indep=False, date
 
 def select_guide_stars(ra, dec, roll, n=5, cone_stars=None, roll_indep=False, date=None):
     if cone_stars is None:
-        cone_stars = agasc.get_agasc_cone(ra, dec, radius=3, date=date, agasc_file='/proj/sot/ska/data/agasc/agasc1p6.h5')
+        cone_stars = agasc.get_agasc_cone(ra, dec, radius=2, date=date, agasc_file='/proj/sot/ska/data/agasc/agasc1p6.h5')
     selected = select_stage_stars(ra, dec, roll, cone_stars,
                                   roll_indep=roll_indep, stype='Guide')
     # Ignore guide star code to use ACA matrix etc to optimize selection of stars in the last

--- a/mini_sausage.py
+++ b/mini_sausage.py
@@ -157,16 +157,17 @@ def check_bad_pixels(cone_stars, not_bad, opt):
     pad = .5 + fixedErrorPad(opt['Type']) * ARC_2_PIX
     # small number of regions to check; vectorize later
     for idx, (rmin, rmax, cmin, cmax) in enumerate(bad_pixels):
-        in_reg = ((r >= (rmin - pad)) & (r <= (rmax + pad))
-                  & (c >= (cmin - pad)) & (c <= (cmax + pad)))
+        in_reg_r = (r >= (rmin - pad)) & (r <= (rmax + pad))
+        in_reg_c = (c >= (cmin - pad)) & (c <= (cmax + pad))
         r_dist = np.min(np.abs(
                 [r - (rmin - pad), r - (rmax + pad)]), axis=0)
+        r_dist[in_reg_r] = 0
         c_dist = np.min(np.abs(
                 [c - (cmin - pad), c - (cmax + pad)]), axis=0)
+        c_dist[in_reg_c] = 0
         # for the nearest manhattan distance, we want the max
         # of the minimums
         min_dist = np.max(np.vstack([r_dist, c_dist]), axis=0)
-        min_dist[in_reg] = 0
         idxmatch = np.argmin([distance, min_dist], axis=0) == 1
         pix_idx[idxmatch] = idx
         distance = np.min([distance, min_dist], axis=0)

--- a/templates/target.html
+++ b/templates/target.html
@@ -56,12 +56,16 @@ so that is the the "best" value an attitude can have.</P>
 {% for col in displaycols -%}
 {% if col == 'nom_acq_tccd' -%}
 <td><a href='{{"%s"|format(row['nom_acq_hash'])}}.html'>{{"%5.2f"|format(row['nom_acq_tccd'])}}</a></td>
-{% elif col == 'nom_gui_5star' -%}
-<td><a href='{{"%s"|format(row['nom_gui_hash'])}}.html'>{{"%5.2f"|format(row['nom_gui_5star'])}}</a></td>
+{% elif col == 'nom_gui_4star' -%}
+<td><a href='{{"%s"|format(row['nom_gui_hash'])}}.html'>{{"%5.2f"|format(row['nom_gui_4star'])}}</a></td>
 {% elif col == 'best_acq_tccd' -%}
 <td><a href='{{"%s"|format(row['best_acq_hash'])}}.html'>{{"%5.2f"|format(row['best_acq_tccd'])}}</a></td>
-{% elif col == 'best_gui_5star' -%}
-<td><a href='{{"%s"|format(row['best_gui_hash'])}}.html'>{{"%5.2f"|format(row['best_gui_5star'])}}</a></td>
+{% elif col == 'best_gui_4star' -%}
+<td><a href='{{"%s"|format(row['best_gui_hash'])}}.html'>{{"%5.2f"|format(row['best_gui_4star'])}}</a></td>
+{% elif col == 'nom_roll' -%}
+<td><a href='{{"roll_%06.2f"|format(row['nom_roll'])}}.json'>{{"%6.2f"|format(row['nom_roll'])}}</a></td>
+{% elif col == 'best_roll' -%}
+<td><a href='{{"roll_%06.2f"|format(row['best_roll'])}}.json'>{{"%6.2f"|format(row['best_roll'])}}</a></td>
 {% else -%}
 <td>{{formats[col]|format(row[col])}}</td>
 {% endif -%}

--- a/templates/target.html
+++ b/templates/target.html
@@ -54,10 +54,14 @@ so that is the the "best" value an attitude can have.</P>
 <thead><tr>{% for col in displaycols %}<th>{{ col }}</th>{% endfor %}</tr></thead>
 {% for row in table %}<tr>
 {% for col in displaycols -%}
-{% if col == 'nom_t_ccd' -%}
-<td><a href='{{"%s"|format(row['nom_id_hash'])}}.html'>{{"%5.2f"|format(row['nom_t_ccd'])}}</a></td>
-{% elif col == 'best_t_ccd' -%}
-<td><a href='{{"%s"|format(row['best_id_hash'])}}.html'>{{"%5.2f"|format(row['best_t_ccd'])}}</a></td>
+{% if col == 'nom_acq_tccd' -%}
+<td><a href='{{"%s"|format(row['nom_acq_hash'])}}.html'>{{"%5.2f"|format(row['nom_acq_tccd'])}}</a></td>
+{% elif col == 'nom_gui_5star' -%}
+<td><a href='{{"%s"|format(row['nom_gui_hash'])}}.html'>{{"%5.2f"|format(row['nom_gui_5star'])}}</a></td>
+{% elif col == 'best_acq_tccd' -%}
+<td><a href='{{"%s"|format(row['best_acq_hash'])}}.html'>{{"%5.2f"|format(row['best_acq_tccd'])}}</a></td>
+{% elif col == 'best_gui_5star' -%}
+<td><a href='{{"%s"|format(row['best_gui_hash'])}}.html'>{{"%5.2f"|format(row['best_gui_5star'])}}</a></td>
 {% else -%}
 <td>{{formats[col]|format(row[col])}}</td>
 {% endif -%}

--- a/templates/toptable.html
+++ b/templates/toptable.html
@@ -6,6 +6,18 @@ table.sortable
 th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sorttable_nosort):after {
     content: " \25B4\25BE"
 }
+table.sortable tbody {
+    counter-reset: sortabletablescope;
+}
+table.sortable thead tr::before {
+    content: "";
+    display: table-cell;
+}
+table.sortable tbody tr::before {
+    content: counter(sortabletablescope);
+    counter-increment: sortabletablescope;
+    display: table-cell;
+}
 </style>
 <script type='text/javascript' src='sorttable.js'></script>
 </HEAD>

--- a/templates/toptable.html
+++ b/templates/toptable.html
@@ -57,7 +57,7 @@ these targets from {{ start }} to {{ stop }}.  Flagged in Red if maximum tempera
 {% endfor %}
 </table>
 
-Release: {{release}} git sha: {{ gitlabel }} MSF Disabled
+Release: {{release}} git sha: {{ gitlabel }} MSF Disabled : chandra_aca version {{ chandra_aca }}
 
 </BODY>
 </HTML>


### PR DESCRIPTION
These changes set the mini_sausage to use at least *more* of the selection parameters for the stages directly from the Matlab characteristics JSON file.  Guide star selection has also been added, but instead of optimizing the selection of stars in the "last" stage by using a merit calculation based on the ACA_ERROR_ARRAY and distance (SAUSAGE method), this code just selects the brightest "OK" stars from the last attempted stage to fill the requested number of candidate entries (which is 9 for guide from the characteristics, though only the first n will be returned by the higher-level selection routine).

The changes in check_sausage.py are not important.  I just used it to explore some of the worst matches (comparing catalogs as retrieved from starcheck and catalogs as they would be created by mini_sausage), but did not use it to generate a quantitative report/analysis.  Qualitatively, the guide star selection matches expectations.  My conclusion is that in the case of many candidates in the last stage that the two selection methods can vary a lot, but we probably don't care as much in those situations (too many good guide stars is a great problem to have).  I found that other causes of mismatches were due to the stars being excluded by SAUSAGE due to the direct catalog search (with very faint spoilers doing the spoiling).  While the mini_sausage has code to replicate that direct catalog search, I have mostly been using the miniagasc, which doesn't have the faint stars *in* it to cause the same spoiling.  Use of a complete AGASC 1.6 in mini_sausage resulted in qualitatively the same rejections as the stars rejected in SAUSAGE.

My plan will likely be to continue to use the miniagasc for work with the evaluator, though it might be better to just remove the "direct catalog search" in the mini_sausage selection instead of crippling it via a catalog without faint stars.


